### PR TITLE
feat: add support to parse and render Natspec from `internal` functions

### DIFF
--- a/src/abiDecoder.ts
+++ b/src/abiDecoder.ts
@@ -61,6 +61,7 @@ export function decodeAbi(abi: AbiElement[]): Doc {
     methods: {},
     events: {},
     errors: {},
+    internalMethods: {},
   };
 
   for (let i = 0; i < abi.length; i += 1) {

--- a/src/dodocTypes.ts
+++ b/src/dodocTypes.ts
@@ -154,4 +154,7 @@ export interface Doc {
   errors: {
     [key: string]: Error;
   };
+  internalMethods: {
+    [key: string]: Method;
+  };
 }

--- a/src/template.sqrl
+++ b/src/template.sqrl
@@ -63,6 +63,53 @@
 
 {{/if}}
 
+{{@if (Object.keys(it.internalMethods).length > 0)}}
+## Internal Methods
+
+{{@foreach(it.internalMethods) => key, val}}
+### {{key.split('(')[0]}}
+
+
+```solidity
+{{val.code}}
+
+```
+
+{{@if (val.notice)}}{{val.notice}}{{/if}}
+
+{{@if (val.details)}}*{{val.details}}*{{/if}}
+
+{{@if (val['custom:requirement'])}}**Requirement:** *{{val['custom:requirement']}}*{{/if}}
+
+{{@if (val['custom:danger'])}}**Danger:** *{{val['custom:danger']}}*{{/if}}
+
+{{@if (val['custom:info'])}}**Info:** *{{val['custom:info']}}*{{/if}}
+
+
+{{@if (Object.keys(val.inputs).length > 0)}}
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+{{@foreach(val.inputs) => key, val}}
+| {{key}} | {{val.type}} | {{val.description}} |
+{{/foreach}}
+{{/if}}
+
+{{@if (Object.keys(val.outputs).length > 0)}}
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+{{@foreach(val.outputs) => key, val}}
+| {{key}} | {{val.type}} | {{val.description}} |
+{{/foreach}}
+
+{{/if}}
+{{/foreach}}
+
+{{/if}}
+
 {{@if (Object.keys(it.events).length > 0)}}
 ## Events
 


### PR DESCRIPTION
# What does this PR introduce?

Add support to parse any Natspec comments mentioned in the Solidity code for `internal` functions.
This apply for both Natspec defined in:
- `library`
- `contract`

The following Natspec comments are supported:
- `@dev`
- `@notice` (although not useful since they are used for user interfaces)
- `@param`
- `@return`
- any `@custom` tag.

This is done by parsing the AST of the contracts and searching the inheritance backwards.

<img width="830" alt="image" src="https://github.com/primitivefinance/primitive-dodoc/assets/31145285/fb98d89e-5f20-4481-93d1-97bd8c617a76">
